### PR TITLE
Make preserve-paths use output dir.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -12,8 +12,10 @@ DESCRIPTION
 
 *   This application recursively extracts compressed archives.
 *   Provide directories to search or provide files to extract.
-*   Supports ZIP, RAR, GZIP, BZIP2, TAR, TGZ, TBZ2, 7ZIP, ISO9660
-*   ie. *.zip *.rar *.r00 *.gz *.bz2 *.tar *.tgz *.tbz2 *.7z *.iso
+*   Supports: ZIP, RAR, GZIP, BZIP2, TAR, TGZ, TBZ2, 7ZIP, ISO9660
+*   Supports: Z, AR, BR, CPIO, DEB, LZ/4, LZIP, LZMA2, S2, SNAPPY
+*   Supports: RPM, SZ, TLZ, TXZ, ZLIB, ZSTD, BROTLI, ZZ
+*   ie: *.zip *.rar *.r00 *.gz *.bz2 *.tar *.tgz *.tbz2 *.7z *.iso (and others)
 
 OPTIONS
 ---
@@ -58,6 +60,9 @@ OPTIONS
     This option determines if the archives will be extracted to their
     parent folder. Using this flag will override the --output option.
 
+-V, --verbose
+    Verbose logging prints the extracted file paths.
+
 -D, --debug
     Enable debug output.
 
@@ -83,6 +88,8 @@ Example TOML job file:
     min_depth = 1
     file_mode = 644
     dir_mode  = 755
+    verbose   = false
+    debug     = false
     preserve_paths = false
 
 AUTHOR

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/spf13/pflag v1.0.6
 	golift.io/version v0.0.2
-	golift.io/xtractr v0.2.3-0.20250419070747-b391d40d7453
+	golift.io/xtractr v0.2.3-0.20250419170021-53bfe05970fe
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ golift.io/cnfgfile v0.0.0-20240713024420-a5436d84eb48 h1:c7cJWRr0cUnFHKtq072esKz
 golift.io/cnfgfile v0.0.0-20240713024420-a5436d84eb48/go.mod h1:zHm9o8SkZ6Mm5DfGahsrEJPsogyR0qItP59s5lJ98/I=
 golift.io/version v0.0.2 h1:i0gXRuSDHKs4O0sVDUg4+vNIuOxYoXhaxspftu2FRTE=
 golift.io/version v0.0.2/go.mod h1:76aHNz8/Pm7CbuxIsDi97jABL5Zui3f2uZxDm4vB6hU=
-golift.io/xtractr v0.2.3-0.20250419070747-b391d40d7453 h1:JnozjdGe8GNAgcLDxd6WjWxVpktsmqJzP2PMT+DulhE=
-golift.io/xtractr v0.2.3-0.20250419070747-b391d40d7453/go.mod h1:invEOYfyBnFtegY2V2n+9K5bUEHB8pGZng1BK0U2r38=
+golift.io/xtractr v0.2.3-0.20250419170021-53bfe05970fe h1:fCqAf/BYLNy5BdX6IeeGIGutHqOANjIfKeYANd5Cktg=
+golift.io/xtractr v0.2.3-0.20250419170021-53bfe05970fe/go.mod h1:invEOYfyBnFtegY2V2n+9K5bUEHB8pGZng1BK0U2r38=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func parseFlags(pwd string) (*xt.Job, *flags) {
 	flag.StringSliceVarP(&job.Passwords, "password", "P", nil, "Attempt these passwords for rar and 7zip archives.")
 	flag.BoolVarP(&job.SquashRoot, "squash-root", "S", false,
 		"If archive contains only 1 folder at in the root, its contents are moved into output folder.")
+	flag.BoolVarP(&job.Verbose, "verbose", "V", false, "Verbose output prints the file list that was extracted.")
 	flag.BoolVarP(&job.DebugLog, "debug", "D", false, "Enable debug output.")
 	flag.StringSliceVarP(&flags.JobFiles, "job-file", "j", nil, "Read additional extraction jobs from these files.")
 	flag.BoolVarP(&job.Preserve, "preserve-paths", "p", false, "Recreate directory hierarchy while extracting.")

--- a/pkg/xt/job.go
+++ b/pkg/xt/job.go
@@ -21,6 +21,7 @@ type Job struct {
 	SquashRoot bool     `json:"squashRoot"    toml:"squash_root"    xml:"squash_root"    yaml:"squashRoot"`
 	DebugLog   bool     `json:"debugLog"      toml:"debug_log"      xml:"debug_log"      yaml:"debugLog"`
 	Preserve   bool     `json:"preservePaths" toml:"preserve_paths" xml:"preserve_paths" yaml:"preservePaths"`
+	Verbose    bool     `json:"verbose"       toml:"verbose"        xml:"verbose"        yaml:"verbose"`
 }
 
 // ParseJobs checks for and reads more jobs in from 0 or more job files.
@@ -48,8 +49,8 @@ func (j *Job) String() string {
 		sSfx = "s"
 	}
 
-	return fmt.Sprintf("%d path%s, f/d-mode:%s/%s, min/max-depth: %d/%d output: %s",
-		len(j.Paths), sSfx, j.FileMode, j.DirMode, j.MinDepth, j.MaxDepth, j.Output)
+	return fmt.Sprintf("%d path%s, f/d-mode:%s/%s, min/max-depth: %d/%d, preserve/squash: %v/%v output: %s",
+		len(j.Paths), sSfx, j.FileMode, j.DirMode, j.MinDepth, j.MaxDepth, j.Preserve, j.SquashRoot, j.Output)
 }
 
 // Debugf prints a log message if debug is enabled.

--- a/pkg/xt/xt.go
+++ b/pkg/xt/xt.go
@@ -49,7 +49,8 @@ func Extract(job *Job) {
 		}
 	}
 
-	log.Printf("==> Done.\n==> Extracted %d archives; wrote %d bytes into %d files in %v",
+	log.Printf("==> Done.")
+	log.Printf("==> Extracted %d archives; wrote %d bytes into %d files in %v",
 		total, size, fCount, time.Since(start).Round(time.Millisecond))
 }
 


### PR DESCRIPTION
- Adds verbose flags to control additional log output.
- Makes `--preserve-paths` use the output path (update from #26).
- Closes #19 