### PR TITLE
Switch module path to golift.io/xt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Unpackerr/xt
+module golift.io/xt
 
 go 1.27.0
 

--- a/main.go
+++ b/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/Unpackerr/xt/pkg/xt"
 	flag "github.com/spf13/pflag"
 	"golift.io/version"
+	"golift.io/xt/pkg/xt"
 	"golift.io/xtractr"
 )
 


### PR DESCRIPTION
## Summary
- Set `go.mod` to `module golift.io/xt` and rewrite the `pkg/xt` import.
- Vanity already serves `go-import: golift.io/xt git https://github.com/Unpackerr/xt`, so `go install golift.io/xt@latest` works after this is tagged.
- New versions will not install via `github.com/Unpackerr/xt`; old tags keep working.

## Test plan
- [ ] `go test ./...` still passes
- [ ] After merge+tag, `go install golift.io/xt@latest` resolves


Made with [Cursor](https://cursor.com)