### PR TITLE
Fix goversioninfo hook after Copilot dropped skip-versioninfo

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,14 +9,13 @@ before:
     - go run github.com/davidnewhall/md2roff@v0.0.1 --manual xt --version "{{.Version}}-{{.Env.REVISION}}" --date "{{.Date}}" MANUAL.md
     - rm -f MANUAL.gz
     - gzip -9 MANUAL
-    # Icon + manifest + VERSIONINFO (Explorer File version). -platform-specific:
-    # Windows is amd64/386/arm64; a single amd64 .syso would miss the others.
-    # FileVersion is the x.y.z prefix of .Version plus REVISION (not .RawVersion:
-    # that stays on the last tag if --nightly is ever used). ProductVersion is
-    # .Version. goversioninfo fills the numeric fields from the FileVersion string.
+    # Icon + manifest + VERSIONINFO. --platform-specific for amd64/386/arm64.
+    # Keep --skip-versioninfo=true on the go run line so YAML/Copilot cannot
+    # treat it as a list item. versioninfo.json is the fallback if skip is
+    # dropped. FileVersion is .Version's x.y.z prefix plus REVISION.
+    # goversioninfo still downloads akavel/rsrc as a library to write the .syso.
     - >-
-      go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0
-      -platform-specific
+      go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.7.0 --platform-specific=true --skip-versioninfo=true
       -icon init/windows/application.ico
       -manifest init/windows/manifest.xml
       -company "Go Lift"
@@ -29,6 +28,7 @@ before:
       -product-version "{{ .Version }}"
       -translation 1033
       -charset 1200
+      init/windows/versioninfo.json
 
 builds:
   - id: xt

--- a/init/windows/README.md
+++ b/init/windows/README.md
@@ -3,4 +3,5 @@ Windows file icon (Explorer / exe Properties), not a tray icon.
 `application.ico` is a multi-size ICO (16, 24, 32, 48, 64, 128, 256) of the
 circular XT emblem from the repo wordmark. `application-256.png` is the same
 art as a square PNG with a transparent background. GoReleaser embeds the ico
-via goversioninfo.
+and VERSIONINFO via goversioninfo. `versioninfo.json` is only a fallback if
+`-skip-versioninfo` is dropped; CLI flags set the version strings.

--- a/init/windows/versioninfo.json
+++ b/init/windows/versioninfo.json
@@ -1,0 +1,41 @@
+{
+  "FixedFileInfo": {
+    "FileVersion": {
+      "Major": 0,
+      "Minor": 0,
+      "Patch": 0,
+      "Build": 0
+    },
+    "ProductVersion": {
+      "Major": 0,
+      "Minor": 0,
+      "Patch": 0,
+      "Build": 0
+    },
+    "FileFlagsMask": "3f",
+    "FileFlags ": "00",
+    "FileOS": "040004",
+    "FileType": "01",
+    "FileSubType": "00"
+  },
+  "StringFileInfo": {
+    "Comments": "",
+    "CompanyName": "Go Lift",
+    "FileDescription": "eXtractor Tool - Recursively decompress archives",
+    "FileVersion": "",
+    "InternalName": "xt",
+    "LegalCopyright": "© Go Lift (https://golift.io)",
+    "LegalTrademarks": "",
+    "OriginalFilename": "xt.exe",
+    "PrivateBuild": "",
+    "ProductName": "xt",
+    "ProductVersion": "",
+    "SpecialBuild": ""
+  },
+  "VarFileInfo": {
+    "Translation": {
+      "LangID": "0409",
+      "CharsetID": "04B0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The v0.2.1 release failed because Copilot Autofix removed `-skip-versioninfo` from the GoReleaser hook, so goversioninfo tried to open a default `versioninfo.json` that was not in the repo.
- The `akavel/rsrc` download is goversioninfo's COFF writer library, not the old rsrc CLI.
- Put `--skip-versioninfo=true` on the `go run` line (YAML-safe) and add `init/windows/versioninfo.json` as a fallback.

## Test plan
- [ ] Merge this, then tag `v0.2.2` (do not re-run `v0.2.1`; that tag still points at the broken hook and GitHub already created an empty release).
- [ ] Confirm the release job no longer errors on `versioninfo.json`.
- [ ] Confirm Windows zips have FileVersion `0.2.2.<REVISION>` in Explorer Properties.


Made with [Cursor](https://cursor.com)